### PR TITLE
fixed(exception): exception 관련 class, enum 추가

### DIFF
--- a/src/main/java/com/example/ifclubserver/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/ifclubserver/common/exception/GlobalExceptionHandler.java
@@ -1,0 +1,14 @@
+package com.example.ifclubserver.common.exception;
+
+import com.example.ifclubserver.member.exception.MemberException;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+    @ExceptionHandler(MemberException.class)
+    public ResponseEntity<Object> handleCustomException(MemberException e) {
+        return ResponseEntity.status(e.getErrorType().getStatus()).body(e.getErrorType().getMessage());
+    }
+}

--- a/src/main/java/com/example/ifclubserver/member/application/impl/MemberServiceImpl.java
+++ b/src/main/java/com/example/ifclubserver/member/application/impl/MemberServiceImpl.java
@@ -10,6 +10,8 @@ import com.example.ifclubserver.member.domain.repository.MemberRepository;
 
 import java.util.Optional;
 
+import com.example.ifclubserver.member.exception.MemberErrorType;
+import com.example.ifclubserver.member.exception.MemberException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -39,8 +41,8 @@ public class MemberServiceImpl implements MemberService {
     @Override
     public MemberDto getMember(Long id) {
         // DB에서 Member 가져오기
-//    Member member = memberRepository.findById(id)
-//        .orElseThrow(() -> CustomError(ErrorCode.MEMBER_NOT_FOUND);
+    Member member = memberRepository.findById(id)
+        .orElseThrow(() -> new MemberException(MemberErrorType.MEMBER_NOT_FOUND));
 
         // 멤버 가져오기 (Optional)
         Optional<Member> optionalMember = memberRepository.findById(id);

--- a/src/main/java/com/example/ifclubserver/member/exception/MemberErrorType.java
+++ b/src/main/java/com/example/ifclubserver/member/exception/MemberErrorType.java
@@ -1,0 +1,18 @@
+package com.example.ifclubserver.member.exception;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public enum MemberErrorType {
+    MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않습니다.");
+
+    private final HttpStatus status;
+    private final String message;
+
+
+    MemberErrorType(HttpStatus status, String message) {
+        this.status = status;
+        this.message = message;
+    }
+}

--- a/src/main/java/com/example/ifclubserver/member/exception/MemberException.java
+++ b/src/main/java/com/example/ifclubserver/member/exception/MemberException.java
@@ -1,0 +1,18 @@
+package com.example.ifclubserver.member.exception;
+
+import lombok.Getter;
+
+@Getter
+public class MemberException extends RuntimeException {
+    private final MemberErrorType errorType;
+
+    public MemberException(MemberErrorType errorType) {
+        super(errorType.getMessage());
+        this.errorType = errorType;
+    }
+
+    public MemberException(MemberErrorType errorType, String message) {
+        super(message);
+        this.errorType = errorType;
+    }
+}


### PR DESCRIPTION
### GlobalExceptionHandler 추가
- 'RestControllerAdvice' 어노테이션을 사용하여 전역 예외 처리기를 구현했습니다.
- 'MemberException'을 처리하는 handleCustomException 메서드를 추가했습니다.
   - 이 메서드는 'MemberException'이 발생했을 때, 예외에 정의된 상태 코드와 메시지를 포함한 'ResponseEntity'를 반환합니다.

### MemberErrorType Enum 추가
- 'HttpStatus'와 메시지를 포함한 'MemberErrorType' 열거형을 추가했습니다.
- 현재는 'MEMBER_NOT_FOUND' 타입이 정의되어 있으며, 이는 회원을 찾을 수 없는 경우에 사용됩니다.
- [Enum에 관한 글](https://inpa.tistory.com/entry/JAVA-%E2%98%95-%EC%97%B4%EA%B1%B0%ED%98%95Enum-%ED%83%80%EC%9E%85-%EB%AC%B8%EB%B2%95-%ED%99%9C%EC%9A%A9-%EC%A0%95%EB%A6%AC#enum%EC%9D%98_%EC%9E%A5%EC%A0%90)

### MemberException 클래스 추가
- 'MemberErrorType'을 포함하는 커스텀 예외 클래스 'MemberException'을 추가했습니다.
- 기본 메시지와 커스텀 메시지를 지원하는 두 가지 생성자를 제공합니다.

### MemberServiceiml 클래스에 있던 예외처리 구체화
- member를 찾지 못할 경우 "존재하지 않습니다."라는 예외를 던집니다.